### PR TITLE
Do not pass `CXXFLAGS`/`LDFLAGS` twice

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,19 +5,13 @@ cmd = run_command('sh', '-c', 'echo $FUZZ_TEST_CFLAGS')
 FUZZ_TEST_CFLAGS = cmd.stdout().strip().strip('\'').split(' ')
 cmd = run_command('sh', '-c', 'echo $FUZZ_TEST_LDFLAGS')
 FUZZ_TEST_LDFLAGS = cmd.stdout().strip().strip('\'').split(' ')
-cmd = run_command('sh', '-c', 'echo $CFLAGS')
-CFLAGS = cmd.stdout().strip().strip('\'').split(' ')
-cmd = run_command('sh', '-c', 'echo $LDFLAGS')
-LDFLAGS = cmd.stdout().strip().strip('\'').split(' ')
-add_global_arguments(CFLAGS, language: 'cpp')
-add_global_link_arguments(LDFLAGS, language: 'cpp')
 
 subdir('src')
 
 executable('demo', 'main.cpp', link_with: explore_me_shared_lib)
 
-executable('my_fuzz_test', 'my_fuzz_test.cpp', 
-link_with: [explore_me_shared_lib], 
+executable('my_fuzz_test', 'my_fuzz_test.cpp',
+link_with: [explore_me_shared_lib],
 cpp_args: [FUZZ_TEST_CFLAGS],
 link_args: FUZZ_TEST_LDFLAGS
 )


### PR DESCRIPTION
Meson already honors `CXXFLAGS` and `LDFLAGS`, so adding them manually actually ended up duplicating flags. This leads to errors for some of them (e.g. `-mllvm -runtime-counter-relocation`).